### PR TITLE
Remove leading 'v' from perl version

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name" : "Backtrace::AsHTML",
   "source-url" : "git://github.com/moznion/p6-Backtrace-AsHTML.git",
-  "perl" : "v6",
+  "perl" : "6",
   "build-depends" : [ ],
   "provides" : {
     "Backtrace::AsHTML" : "lib/Backtrace/AsHTML.pm6"


### PR DESCRIPTION
It's a trivial change, but Panda reports this when installing:

==> Fetching Backtrace::AsHTML
Please remove leading 'v' from perl version in Backtrace::AsHTML's meta info.

I'm doing this with my own modules as well, it's a minor change but it makes
the install look cleaner.
