### PR TITLE
Don't test actual line numbers

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -17,10 +17,7 @@ my sub bar(Int $arg) {
 }
 bar(2);
 
-like $html, rx{'in block &lt;unit&gt; at t/01-basic.t line 18'};
-like $html, rx{'in bar at t/01-basic.t line 18'};
-like $html, rx{'in foo at t/01-basic.t line 15'};
-like $html, rx{'in new at t/01-basic.t line 11'};
-
-done-testing;
-
+like $html, rx{'in block &lt;unit&gt; at t/01-basic.t line '\d+};
+like $html, rx{'in bar at t/01-basic.t line '\d+};
+like $html, rx{'in foo at t/01-basic.t line '\d+};
+like $html, rx{'in new at t/01-basic.t line '\d+};


### PR DESCRIPTION
Different implementations may print slightly different line numbers
(in fact, the whole backtrace can be slightly different). Line numbers
were fixed between rakudo 2018.12 and 2019.01, this commit relaxes the
checks slightly.