### PR TITLE
Fix the match in the test

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -19,7 +19,7 @@ bar(2);
 
 like $html, rx{'in block &lt;unit&gt; at t/01-basic.t line 18'};
 like $html, rx{'in bar at t/01-basic.t line 18'};
-like $html, rx{'in foo at t/01-basic.t line 15'};
+like $html, rx{'in foo at t/01-basic.t line 16'};
 like $html, rx{'in new at t/01-basic.t line 11'};
 
 done-testing;


### PR DESCRIPTION
It's a mystery why this just started failing recently as the call
to foo() is indeed at line 16 and doesn't appear to have moved at
all. Ho hum.