### PR TITLE
Fix test

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -19,7 +19,7 @@ bar(2);
 
 like $html, rx{'in block &lt;unit&gt; at t/01-basic.t line 18'};
 like $html, rx{'in bar at t/01-basic.t line 18'};
-like $html, rx{'in foo at t/01-basic.t line 15'};
+like $html, rx{'in foo at t/01-basic.t line 16'};
 like $html, rx{'in new at t/01-basic.t line 11'};
 
 done-testing;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -20,7 +20,6 @@ bar(2);
 like $html, rx{'in block &lt;unit&gt; at t/01-basic.t line 18'};
 like $html, rx{'in bar at t/01-basic.t line 18'};
 like $html, rx{'in foo at t/01-basic.t line 16'};
-like $html, rx{'in new at t/01-basic.t line 11'};
 
 done-testing;
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -3,7 +3,7 @@ use lib 'lib';
 use Test;
 use Backtrace::AsHTML;
 
-plan 4;
+plan 3;
 
 my $html;
 


### PR DESCRIPTION
   The Backtrace.new doesn't appear in backtrace frames
    
    This was a change since the last release of Rakudo

